### PR TITLE
Language switch

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,13 +1,16 @@
+"use client";
+
 import SiteHeader from "@/components/SiteHeader/SiteHeader";
 import SiteFooter from "@/components/SiteFooter/SiteFooter";
 import OnboardingModal from "@/components/user-onbording/OnboardingModal";
 import { SiteAccountGuard } from "@/components/auth/AccountRouteGuards";
+import LanguageToggle from "@/components/SiteHeader/LanguageToggle";
 
 export default function SiteLayout({ children }: { children: React.ReactNode }) {
   return (
     <SiteAccountGuard>
       <OnboardingModal />
-      
+
       <SiteHeader />
       <main className="pt-20">
         {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Outfit } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/context/AuthContext";
+import { LangProvider } from "@/context/LangContext";
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { Analytics } from '@vercel/analytics/next';
 import { Theme } from "@radix-ui/themes";
@@ -83,6 +84,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <SpeedInsights />
         <Analytics />
         <AuthProvider>
+        <LangProvider>
             <Theme>
               <ScrollToTop />
               <main>{children}</main>
@@ -98,6 +100,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 theme="light"
               />
             </Theme>
+        </LangProvider>
         </AuthProvider>
       </body>
     </html>

--- a/components/SiteHeader/LanguageToggle.tsx
+++ b/components/SiteHeader/LanguageToggle.tsx
@@ -1,0 +1,103 @@
+import { useLang, ENGLISH, SWEDISH } from "@/context/LangContext";
+import { motion } from "framer-motion";
+import { useState, useEffect } from "react";
+
+type Props = {
+    className?: string,
+    disabled?: boolean,
+    fullWidth?: boolean,
+};
+
+export default function LanguageToggle({
+  className = "",
+  disabled = false,
+  fullWidth = false,
+}: Props) {
+    const { setLang } = useLang();
+    const [ selectedIndex, setSelectedIndex ] = useState<number>(0);
+    const widthClass = fullWidth
+    ? "w-full"
+    : "w-[128px] sm:w-[144px] xl:w-[152px]";
+
+    const options = [ 
+        {
+            key: SWEDISH,
+            index: 0,
+            label: "Svenska", 
+        },
+        {
+            key: ENGLISH,
+            index: 1,
+            label: "English",
+        },
+    ];
+
+    useEffect(() => {
+        setLang([SWEDISH, ENGLISH][selectedIndex]);
+    }, [selectedIndex]);
+
+    return (
+    <div
+      role="tablist"
+      aria-disabled={disabled}
+      className={[
+        "relative inline-grid grid-cols-2 items-center",
+        "h-8 sm:h-9",
+        widthClass,
+        "rounded-full bg-white",
+        "border border-black/10",
+        "shadow-[0_6px_18px_rgba(0,0,0,0.08)]",
+        "overflow-hidden",
+        disabled ? "opacity-60 pointer-events-none" : "",
+        className,
+      ].join(" ")}
+    >
+      {/* sliding highlight */}
+      <motion.div
+        aria-hidden
+        className={[
+          "absolute inset-y-0 left-0 w-1/2",
+          "bg-[#004225]",
+          "shadow-[0_4px_12px_rgba(0,66,37,0.22)]",
+        ].join(" ")}
+        initial={false}
+        animate={{
+          x: `${selectedIndex * 100}%`,
+          borderTopLeftRadius: selectedIndex === 0 ? "999px" : "0px",
+          borderBottomLeftRadius: selectedIndex === 0 ? "999px" : "0px",
+          borderTopRightRadius: selectedIndex === 1 ? "999px" : "0px",
+          borderBottomRightRadius: selectedIndex === 1 ? "999px" : "0px",
+        }}
+        transition={{
+          duration: 0.32,
+          ease: [0.22, 1, 0.36, 1],
+        }}
+      />
+
+      {options.map((opt) => {
+        const active = opt.index === selectedIndex;
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-label={opt.label}
+            onClick={() => { 
+                setSelectedIndex(opt.index); 
+            }}
+            className={[
+              "relative z-10 h-full w-full flex items-center justify-center gap-2 rounded-full",
+              "text-xs font-medium tracking-tight",
+              "transition-colors duration-200",
+              active ? "text-white" : "text-black/80",
+            ].join(" ")}
+          >
+            <span>{opt.label}</span>
+          </button>
+        );
+      })}
+    </div>
+    );
+}
+

--- a/components/SiteHeader/SiteHeader.tsx
+++ b/components/SiteHeader/SiteHeader.tsx
@@ -19,56 +19,9 @@ import {
   type NavbarItem,
 } from "@/components/ui/resizable-navbar";
 import LanguageToggle from "./LanguageToggle";
+import { staticTranslate, useLang } from "@/context/LangContext";
 
 type NavItem = NavbarItem;
-
-const publicNavItems: NavItem[] = [
-  { name: "Bostäder", link: "/bostader" },
-  { name: "Alla köer", link: "/alla-koer" },
-  { name: "Kom igång", link: "/" },
-];
-
-const studentNavItems: NavItem[] = [
-  {
-    name: "Bostäder",
-    link: "/bostader",
-    dropdown: [
-      { name: "Sök bostäder", link: "/bostader" },
-      { name: "Mina ansökningar", link: "/ansokningar" },
-      { name: "Sparade", link: "/sparade" },
-    ],
-  },
-  {
-    name: "Alla köer",
-    link: "/alla-koer",
-    dropdown: [
-      { name: "Lägg till köer", link: "/alla-koer" },
-      { name: "Mina köer", link: "/koer" },
-    ],
-  },
-  { name: "Notiser", link: "/notiser" },
-];
-
-const landlordNavItems: NavItem[] = [
-  { name: "Bostäder", link: "/bostader" },
-  {
-    name: "Mina annonser",
-    link: "/mina-annonser",
-    dropdown: [
-      { name: "Skapa ny", link: "/mina-annonser/ny" },
-      { name: "Mina annonser", link: "/mina-annonser" },
-      { name: "Ansökningar", link: "/ansokningar" },
-    ],
-  },
-  { name: "Notiser", link: "/notiser" },
-];
-
-const getRoleLabel = (accountType?: string | null) => {
-  if (accountType === "student") return "Student";
-  if (accountType === "private_landlord") return "Privat uthyrare";
-  if (accountType === "company") return "Företag";
-  return null;
-};
 
 const getInitial = (value: string) => value.trim().charAt(0).toUpperCase() || "C";
 
@@ -116,9 +69,58 @@ function AccountAvatar({
 
 export default function SiteHeader() {
   const { user, logout, isLoading } = useAuth();
+  const { lang } = useLang();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isAccountMenuOpen, setIsAccountMenuOpen] = useState(false);
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const publicNavItems: NavItem[] = [
+    { name: staticTranslate({ "se-SE": "Bostäder", "en-US": "Apartments" }, lang), link: "/bostader" },
+    { name: staticTranslate({ "se-SE": "Alla köer", "en-US": "Queues" }, lang), link: "/alla-koer" },
+    { name: staticTranslate({ "se-SE": "Kom igång", "en-US": "Get started" }, lang), link: "/" },
+  ];
+  
+  const studentNavItems: NavItem[] = [
+    {
+      name: staticTranslate({ "se-SE": "Bostäder", "en-US": "Apartments" }, lang),
+      link: "/bostader",
+      dropdown: [
+        { name: staticTranslate({ "se-SE": "Sök bostäder", "en-US": "Find apartments" }, lang), link: "/bostader" },
+        { name: staticTranslate({ "se-SE": "Mina ansökningar", "en-US": "My applications" }, lang), link: "/ansokningar" },
+        { name: staticTranslate({ "se-SE": "Sparade", "en-US": "Savings" }, lang), link: "/sparade" },
+      ],
+    },
+    {
+      name: staticTranslate({ "se-SE": "Alla köer", "en-US": "Queues" }, lang),
+      link: "/alla-koer",
+      dropdown: [
+        { name: staticTranslate({ "se-SE": "Lägg till köer", "en-US": "Add queues" }, lang), link: "/alla-koer" },
+        { name: staticTranslate({ "se-SE": "Mina köer", "en-US": "My queues" }, lang), link: "/koer" },
+      ],
+    },
+    { name: staticTranslate({ "se-SE": "Notiser", "en-US": "Notifications" }, lang), link: "/notiser" },
+  ];
+  
+  const landlordNavItems: NavItem[] = [
+    { name: staticTranslate({ "se-SE": "Bostäder", "en-US": "Apartments" }, lang), link: "/bostader" },
+    {
+      name: staticTranslate({ "se-SE": "Mina annonser", "en-US": "My listings" }, lang),
+      link: "/mina-annonser",
+      dropdown: [
+        { name: staticTranslate({ "se-SE": "Skapa ny", "en-US": "New listing" }, lang), link: "/mina-annonser/ny" },
+        { name: staticTranslate({ "se-SE": "Mina annonser", "en-US": "My listings" }, lang), link: "/mina-annonser" },
+        { name: staticTranslate({ "se-SE": "Ansökningar", "en-US": "Applications" }, lang), link: "/ansokningar" },
+      ],
+    },
+    { name: staticTranslate({ "se-SE": "Notiser", "en-US": "Notifications" }, lang), link: "/notiser" },
+  ];
+  
+  const getRoleLabel = (accountType?: string | null) => {
+    if (accountType === "student") return "Student";
+    if (accountType === "private_landlord") return staticTranslate({ "se-SE": "Privat uthyrare", "en-US": "Private landlord" }, lang);
+    if (accountType === "company") return staticTranslate({ "se-SE": "Företag", "en-US": "Company" }, lang);
+    return null;
+  };
 
   const userType = user?.accountType;
   const roleLabel = getRoleLabel(userType);
@@ -132,26 +134,26 @@ export default function SiteHeader() {
   } else if (userType === "private_landlord" || userType === "company") {
     navItems = landlordNavItems;
   } else if (user) {
-    navItems = [{ name: "Bostadssök", link: "/bostader" }];
+    navItems = [{ name: staticTranslate({ "se-SE": "Bostadssök", "en-US": "Find apartments" }, lang), link: "/bostader" }];
   }
 
   let accountMenuItems: NavItem[] = [];
 
   if (userType === "student") {
     accountMenuItems = [
-      { name: "Mitt konto", link: "/profil" },
-      { name: "Inställningar", link: "/installningar" },
-      { name: "Hjälp", link: "/faq" },
+      { name: staticTranslate({ "se-SE": "Mitt konto", "en-US": "My account" }, lang), link: "/profil" },
+      { name: staticTranslate({ "se-SE": "Inställningar", "en-US": "Settings" }, lang), link: "/installningar" },
+      { name: staticTranslate({ "se-SE": "Hjälp", "en-US": "Help" }, lang), link: "/faq" },
     ];
   } else if (userType === "private_landlord" || userType === "company") {
     accountMenuItems = [
-      { name: "Mitt konto", link: "/profil" },
-      { name: "Inställningar", link: "/installningar" },
-      { name: "Fakturering", link: "/fakturering" },
-      { name: "Hjälp", link: "/faq" },
+      { name: staticTranslate({ "se-SE": "Mitt konto", "en-US": "" }, lang), link: "/profil" },
+      { name: staticTranslate({ "se-SE": "Inställningar", "en-US": "" }, lang), link: "/installningar" },
+      { name: staticTranslate({ "se-SE": "Fakturering", "en-US": "" }, lang), link: "/fakturering" },
+      { name: staticTranslate({ "se-SE": "Hjälp", "en-US": "" }, lang), link: "/faq" },
     ];
   } else if (user) {
-    accountMenuItems = [{ name: "Mitt konto", link: "/profil" }];
+    accountMenuItems = [{ name: staticTranslate({ "se-SE": "Mitt konto", "en-US": "My account" }, lang), link: "/profil" }];
   }
 
   const closeMenus = () => {
@@ -230,7 +232,10 @@ export default function SiteHeader() {
         <Link
           href="/"
           className="relative z-20 flex items-center gap-2 px-2 py-1 text-sm font-medium"
-          aria-label="Gå till startsidan"
+          aria-label={staticTranslate({ 
+              "se-SE": "Gå till startsidan", 
+              "en-US": "Go to the start page", 
+          }, lang)}
         >
           <Image
             src="/campuslyan-logo.svg"
@@ -252,13 +257,13 @@ export default function SiteHeader() {
                 href="/logga-in"
                 className="inline-flex rounded-full px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100"
               >
-                Logga in
+                {staticTranslate({ "se-SE": "Logga in", "en-US": "Log in" }, lang)}
               </Link>
               <Link
                 href="/registrera"
                 className="inline-flex rounded-full bg-[#004225] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[#00341d]"
               >
-                Skapa konto
+                {staticTranslate({ "se-SE": "Skapa konto", "en-US": "New account" }, lang)}
               </Link>
             </>
           ) : (
@@ -326,7 +331,7 @@ export default function SiteHeader() {
                     onClick={handleLogout}
                     className="mt-2 w-full rounded-xl px-3 py-2.5 text-left text-sm font-medium text-red-600 transition hover:bg-red-50"
                   >
-                    Logga ut
+                    {staticTranslate({ "se-SE": "Logga ut", "en-US": "Log out"}, lang)}
                   </button>
                 </div>
               )}
@@ -388,13 +393,14 @@ export default function SiteHeader() {
                   onClick={closeMenus}
                   className="mt-2 inline-flex w-full items-center justify-center rounded-full border border-neutral-200 px-5 py-3 text-base font-medium text-neutral-700 transition hover:bg-neutral-50"
                 >
-                  Logga in
+                    {staticTranslate({ "se-SE": "Logga in", "en-US": "Log in" }, lang)}
                 </Link>
                 <Link
                   href="/registrera"
                   onClick={closeMenus}
                   className="inline-flex w-full items-center justify-center rounded-full bg-[#004225] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#00341d]"
                 >
+                  {staticTranslate({ "se-SE": "Skapa konto", "en-US": "New account" }, lang)}
                   Skapa konto
                 </Link>
               </>
@@ -436,7 +442,7 @@ export default function SiteHeader() {
                   onClick={handleLogout}
                   className="mt-1 w-full rounded-xl px-3 py-2.5 text-left text-sm font-medium text-red-600 transition hover:bg-red-50"
                 >
-                  Logga ut
+                    {staticTranslate({ "se-SE": "Logga ut", "en-US": "Log out" }, lang)}
                 </button>
               </div>
             )}

--- a/components/SiteHeader/SiteHeader.tsx
+++ b/components/SiteHeader/SiteHeader.tsx
@@ -18,6 +18,7 @@ import {
   Navbar,
   type NavbarItem,
 } from "@/components/ui/resizable-navbar";
+import LanguageToggle from "./LanguageToggle";
 
 type NavItem = NavbarItem;
 
@@ -224,6 +225,7 @@ export default function SiteHeader() {
 
   return (
     <Navbar className="top-4">
+      <LanguageToggle className="ml-4"/>
       <NavBody>
         <Link
           href="/"
@@ -241,7 +243,6 @@ export default function SiteHeader() {
             <span className="text-base">CampusLyan</span>
           </div>
         </Link>
-
         <NavItems items={navItems} onItemClick={() => setIsAccountMenuOpen(false)} />
 
         <div className="relative z-20 hidden items-center gap-2 lg:flex">

--- a/context/LangContext.tsx
+++ b/context/LangContext.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * Language context.
+ *
+ * Provide per-language options:
+ *
+ *      return (
+ *          <p>
+ *          {staticTranslate({
+ *              [SWEDISH]: "Hej!",
+ *              [ENGLISH]: "Hello!"
+ *          })} 
+ *          </p>);
+ *
+ * Dynamically translate content:
+ *
+ *      const [text, setText] = useState<string>("");
+ *      useEffect(() => {
+ *          (async () => {
+ *              setText(await service.getText());
+ *          })();
+ *      }, []);
+ *      return (
+ *          <p>
+ *          {dynamicTranslate(text)}
+ *          </p>
+ *      );
+ *
+ * Get/set the active locale:
+ *      const { lang, setLang } = useLang();
+ *      setLang(ENGLISH);
+ */
+
+import React, { createContext, useContext, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+
+export type Lang = "se-SE" | "en-US";
+
+export const SWEDISH: Lang = "se-SE";
+export const ENGLISH: Lang = "en-US";
+
+export type LangCtx = {
+    lang: Lang,
+    setLang: (to: Lang) => void,
+};
+
+const Ctx = createContext<LangCtx | undefined>(undefined);
+
+export function LangProvider({ children }: { children: React.ReactNode }) {
+    const [lang, setLang] = useState<Lang>(SWEDISH);
+    return (
+        <Ctx.Provider value={{
+            lang, 
+            setLang
+        }}>
+            {children}
+        </Ctx.Provider>
+    );
+}
+
+/**
+ * Get access to the language context.
+ *
+ * Enables the caller to set, or detect the used language.
+ *
+ * The language follows the international locale format, meaning
+ * the Swedish language will be "se-SE" and English "en-US". For 
+ * the sake of consistency, it is recommended that the SWEDISH, 
+ * and ENGLISH constants (defined in this module) are used instead 
+ * of the raw strings.
+ */
+export function useLang() {
+    const ctx = useContext(Ctx);
+    if (!ctx) {
+        throw new Error("useLang must be used within LangProvider");
+    }
+    return ctx;
+}
+
+/**
+ * Statically translate a text snippet.
+ *
+ * This function requires that the caller supplies each translation manually
+ * using a record. The keys in this record should be of the locale string format,
+ * I.e "se-SE" for Swedish and "en-US" for English.
+ *
+ */
+export function staticTranslate(translations: Record<Lang, string>): string {
+    if (!translations[SWEDISH]) {
+        throw new Error("The SWEDISH ('se-SE') language has to be provided.");
+    }
+    const { lang } = useLang();
+    return translations[lang] || translations[SWEDISH];
+}
+
+/**
+ * Dynamically translate contents.
+ *
+ * Uses react-i18next to dynamically translate the given text by the enabled locale.
+ */
+export function dynamicTranslate(text: string): string {
+    const { lang } = useLang();
+    const { t, i18n } = useTranslation();
+    i18n.changeLanguage(lang as string);
+    return t(text);
+}
+

--- a/context/LangContext.tsx
+++ b/context/LangContext.tsx
@@ -33,7 +33,7 @@
  */
 
 import React, { createContext, useContext, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation, UseTranslationResponse } from "react-i18next";
 
 
 export type Lang = "se-SE" | "en-US";
@@ -87,23 +87,11 @@ export function useLang() {
  * I.e "se-SE" for Swedish and "en-US" for English.
  *
  */
-export function staticTranslate(translations: Record<Lang, string>): string {
+export function staticTranslate(translations: Record<Lang, string>, lang: Lang): string {
     if (!translations[SWEDISH]) {
         throw new Error("The SWEDISH ('se-SE') language has to be provided.");
     }
-    const { lang } = useLang();
     return translations[lang] || translations[SWEDISH];
 }
 
-/**
- * Dynamically translate contents.
- *
- * Uses react-i18next to dynamically translate the given text by the enabled locale.
- */
-export function dynamicTranslate(text: string): string {
-    const { lang } = useLang();
-    const { t, i18n } = useTranslation();
-    i18n.changeLanguage(lang as string);
-    return t(text);
-}
 

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -1,0 +1,9 @@
+
+export function getActiveLanguage(): string {
+    return localStorage.getItem("CampusLyan_language") || "se";
+}
+
+export function altText(txt: Record<string, string>): string {
+    return txt[getActiveLanguage()] || txt.se;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "react-day-picker": "^9.13.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.66.1",
+        "react-i18next": "^17.0.4",
         "react-icons": "^5.5.0",
         "react-leaflet": "^5.0.0",
         "recharts": "^2.15.4",
@@ -102,9 +103,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3458,15 +3459,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
       "cpu": [
         "arm64"
       ],
@@ -3480,9 +3481,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
       "cpu": [
         "x64"
       ],
@@ -3496,11 +3497,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3512,11 +3516,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3528,11 +3535,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3544,11 +3554,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3560,9 +3573,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -3576,9 +3589,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
       "cpu": [
         "x64"
       ],
@@ -8421,6 +8434,47 @@
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.0.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.6.tgz",
+      "integrity": "sha512-A4U6eCXodIbrhf8EarRurB9/4ebyaurH4+fu4gig9bqxmpSt+fCAFm/GpRQDcN1Xzu/LdFCx4nYHsnM1edIIbg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/input-otp": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.1.tgz",
@@ -8751,9 +8805,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -8895,14 +8949,14 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -8914,15 +8968,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -9386,6 +9440,33 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+      "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.0.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
@@ -9826,7 +9907,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9960,6 +10041,15 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-day-picker": "^9.13.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.66.1",
+    "react-i18next": "^17.0.4",
     "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
     "recharts": "^2.15.4",


### PR DESCRIPTION
# Multilingual support

This branch adds a context for storing site-wide language, as well as a mechanism for translating content statically.
It also introduces a simple switch at the top left for changing between Swedish and English, as well as a few translations.

## Basic usage

In order to allow translations, you need to add a hook into the language context. The site-layout has been made a language context, so it should be applicable wherever. The context is available as `@/context/LangContext`. This module exposes these components:
```typescript
type Lang = "se-SE" | "en-US";
const SWEDISH: Lang = "se-SE";
const ENGLISH: Lang = "en-US";
type LangContext = {
    lang: Lang,
    setLang: (Lang) => void,
};
useLang: () => LangContext
staticTranslate: (Record<Lang, string>, Lang) => string
```
At bare minimum, one needs to invoke `useLang()` to get the current language `lang: Lang`. After that, child components may use the already provided `staticTranslate` function to resolve the text alternatives automatically when `lang` changes.

Example:
```typescript
import { useLang, staticTranslate } from "@/context/LangContext";

export function Component() {
    const { lang } = useLang();
    return <span> {staticTranslate({ "se-SE": "Hej!", "en-US": "Hello" }, lang)} </span>
}
```
You can also optionally use `setLang` to overwrite the current language. Note that this is already handled by `LanguageSwitch.tsx` though, so calling it yourself is inadvisable. 